### PR TITLE
fix(android): Add bundle step to release workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,12 +32,15 @@ jobs:
       - name: 5. Grant execute permission to gradlew
         run: chmod +x android/gradlew
 
-      - name: 6. Build Android Release
+      - name: 6. Create Android bundle
+        run: npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
+
+      - name: 7. Build Android Release
         run: |
           cd android
           ./gradlew assembleRelease
 
-      - name: 6. Upload APK artifact
+      - name: 8. Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: app-release.apk


### PR DESCRIPTION
The release APK was crashing on launch because the JavaScript bundle was not being included in the build. This is a common issue in CI environments where the `assembleRelease` task does not automatically trigger the bundling process.

This change adds an explicit step to the GitHub Actions workflow to run `npx react-native bundle` before the `assembleRelease` task. This ensures that the JavaScript bundle and assets are generated and correctly placed in the `android/app/src/main/assets` directory, allowing the native app to load them correctly.