### PR TITLE
fix(android): Create assets dir before bundling in release workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -33,7 +33,9 @@ jobs:
         run: chmod +x android/gradlew
 
       - name: 6. Create Android bundle
-        run: npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
+        run: |
+          mkdir -p android/app/src/main/assets
+          npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
 
       - name: 7. Build Android Release
         run: |


### PR DESCRIPTION
This commit corrects the previous fix for the Android release build. The `react-native bundle` command was failing with an ENOENT error because the destination directory, `android/app/src/main/assets`, did not exist in the CI environment.

This change modifies the workflow to run `mkdir -p android/app/src/main/assets` immediately before the bundle command. This ensures the directory exists, allowing the bundle and assets to be created successfully, which should resolve the build failure and the subsequent app crash.