### PR TITLE
fix(android): Clean duplicate resources before build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,17 +32,20 @@ jobs:
       - name: 5. Grant execute permission to gradlew
         run: chmod +x android/gradlew
 
-      - name: 6. Create Android bundle
+      - name: 6. Clean up duplicate resources
+        run: find android/app/src/main/res/ -name "node_modules_*" -type f -delete
+
+      - name: 7. Create Android bundle
         run: |
           mkdir -p android/app/src/main/assets
           npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
 
-      - name: 7. Build Android Release
+      - name: 8. Build Android Release
         run: |
           cd android
           ./gradlew assembleRelease
 
-      - name: 8. Upload APK artifact
+      - name: 9. Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: app-release.apk


### PR DESCRIPTION
This commit resolves the "Duplicate resources" error that occurred during the Android release build.

The error was caused by image assets being present in the `android/app/src/main/res` directory in the source code, which conflicted with the assets generated by the `react-native bundle` command during the CI process.

This change introduces a new step in the GitHub Actions workflow to find and delete these pre-existing, conflicting assets before the bundling and build steps are run. This ensures a clean build environment and prevents resource merging failures.