### PR TITLE
fix(android): Use rm to clean duplicate resources in build workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -33,7 +33,7 @@ jobs:
         run: chmod +x android/gradlew
 
       - name: 6. Clean up duplicate resources
-        run: find android/app/src/main/res/ -name "node_modules_*" -type f -delete
+        run: rm -f android/app/src/main/res/drawable-*/node_modules_*
 
       - name: 7. Create Android bundle
         run: |


### PR DESCRIPTION
This commit provides a more robust fix for the "Duplicate resources" error during the Android release build.

Previous attempts using `find` were not effective. This change replaces the `find` command with a more direct `rm -f` command using a glob pattern. This ensures that any pre-existing, conflicting assets in the `android/app/src/main/res/drawable-*` directories are forcefully removed before the build process begins.

This should finally resolve the resource merging failures and allow the build to complete successfully.