### PR TITLE
chore(build): Add diagnostic steps to debug resource error

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,8 +32,15 @@ jobs:
       - name: 5. Grant execute permission to gradlew
         run: chmod +x android/gradlew
 
-      - name: 6. Clean up duplicate resources
-        run: rm -f android/app/src/main/res/drawable-*/node_modules_*
+      - name: 6. Diagnose and clean resources
+        run: |
+          echo "--- Listing resources BEFORE cleanup ---"
+          ls -R android/app/src/main/res/
+          echo "--- Running cleanup command ---"
+          rm -f android/app/src/main/res/drawable-*/node_modules_*
+          echo "--- Listing resources AFTER cleanup ---"
+          ls -R android/app/src/main/res/
+          echo "--- Diagnosis complete ---"
 
       - name: 7. Create Android bundle
         run: |


### PR DESCRIPTION
This commit adds temporary diagnostic steps to the Android build workflow to investigate a persistent "Duplicate resources" error.

The build is failing because of a conflict between checked-in assets and build-generated assets. Previous attempts to delete the checked-in assets have failed. This change adds `ls -R` commands before and after the cleanup step to log the file system state and determine why the deletion is not working.

This change is for debugging only and is not expected to produce a successful build. The logs from this workflow run will be used to create a final fix.