### PR TITLE
fix(android): Disable Gradle bundle and finalize workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,15 +32,8 @@ jobs:
       - name: 5. Grant execute permission to gradlew
         run: chmod +x android/gradlew
 
-      - name: 6. Diagnose and clean resources
-        run: |
-          echo "--- Listing resources BEFORE cleanup ---"
-          ls -R android/app/src/main/res/
-          echo "--- Running cleanup command ---"
-          rm -f android/app/src/main/res/drawable-*/node_modules_*
-          echo "--- Listing resources AFTER cleanup ---"
-          ls -R android/app/src/main/res/
-          echo "--- Diagnosis complete ---"
+      - name: 6. Clean up duplicate resources
+        run: rm -f android/app/src/main/res/drawable-*/node_modules_*
 
       - name: 7. Create Android bundle
         run: |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,7 @@ apply plugin: "com.facebook.react"
  * By default you don't need to apply any configuration, just uncomment the lines you need.
  */
 react {
+    bundleInRelease = false
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '..'
     // root = file("../")


### PR DESCRIPTION
This commit provides a definitive fix for the Android release build failures. The root cause was a conflict between the manually invoked `react-native bundle` command and Gradle's own internal bundling process (`createBundleReleaseJsAndAssets`), both of which were creating asset files and causing a "Duplicate resources" error.

This fix resolves the issue by:
1.  Disabling Gradle's internal bundler for release builds by setting `bundleInRelease = false` in `android/app/build.gradle`. This makes the manual bundling step the single source of truth.
2.  Ensuring the workflow robustly cleans up any pre-existing, checked-in assets before the manual bundling occurs, preventing any possible conflicts.

This new configuration ensures a clean, predictable build process where asset creation is handled by a single, explicit step.