### PR TITLE
fix(android): Disable conflicting Gradle task to fix build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,6 @@ apply plugin: "com.facebook.react"
  * By default you don't need to apply any configuration, just uncomment the lines you need.
  */
 react {
-    bundleInRelease = false
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '..'
     // root = file("../")
@@ -122,3 +121,9 @@ dependencies {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+
+tasks.whenTaskAdded { task ->
+    if (task.name == 'createBundleReleaseJsAndAssets') {
+        task.enabled = false
+    }
+}


### PR DESCRIPTION
This commit provides a definitive fix for the Android release build failures. The root cause was a conflict between the manually invoked `react-native bundle` command and Gradle's own internal bundling task (`createBundleReleaseJsAndAssets`).

My previous attempt to fix this using a `bundleInRelease` flag failed because that property does not exist in this version of the React Native Gradle Plugin.

This fix resolves the issue by:
1.  Removing the incorrect `bundleInRelease` property.
2.  Adding a `tasks.whenTaskAdded` block to the `android/app/build.gradle` file to explicitly disable the `createBundleReleaseJsAndAssets` task.

This ensures that the manual bundling step in the GitHub Actions workflow is the single source of truth for assets, finally resolving the "Duplicate resources" error and allowing the build to complete.